### PR TITLE
Feature: Add Asynchronous Audio Streaming Support

### DIFF
--- a/tests/play_tts.py
+++ b/tests/play_tts.py
@@ -1,0 +1,81 @@
+from supertonic_mnn import SupertonicTTS
+import sounddevice as sd
+import numpy as np
+
+def read_file_to_string(filename):
+    try:
+        with open(filename, 'r', encoding='utf-8') as file:
+            # Read the entire file content into a single string variable
+            file_contents = file.read()
+        return file_contents
+    except FileNotFoundError:
+        return f"Error: The file '{filename}' was not found."
+    except Exception as e:
+        return f"An unexpected error occurred: {e}"
+
+file_name = 'tts.txt'
+data_string = read_file_to_string(file_name)
+
+# Initialize
+tts = SupertonicTTS()
+
+# Synthesize using Stream
+# Models will be downloaded automatically if not present
+print(f"Synthesizing and playing text from {file_name}...")
+
+import queue
+import threading
+
+# Queue to hold audio chunks
+audio_queue = queue.Queue()
+playback_finished = threading.Event()
+
+def playback_thread_func(sample_rate):
+    stream = sd.OutputStream(samplerate=sample_rate, channels=1, dtype='float32')
+    stream.start()
+    
+    try:
+        while True:
+            chunk = audio_queue.get()
+            if chunk is None:  # Sentinel value to signal end of stream
+                break
+
+            # Prepare data and write to stream (this call blocks if buffer full)
+            audio_data = chunk.flatten().astype('float32')
+            stream.write(audio_data)
+    except Exception as e:
+        print(f"Playback error: {e}")
+    finally:
+        stream.stop()
+        stream.close()
+        playback_finished.set()
+
+stream_gen = tts.synthesize_stream(data_string, voice="F1", steps=9)
+audio_thread = None
+
+try:
+    first_chunk = True
+    for audio_chunk, sample_rate in stream_gen:
+        # On first chunk, start the playback thread
+        if first_chunk:
+            audio_thread = threading.Thread(target=playback_thread_func, args=(sample_rate,))
+            audio_thread.daemon = True # Daemon thread dies if main program exits
+            audio_thread.start()
+            print("Playback started...")
+            first_chunk = False
+        
+        # Put generated chunk into the queue for the consumer thread
+        audio_queue.put(audio_chunk)
+
+    # Signal end of playback
+    if audio_thread:
+        audio_queue.put(None)
+        # Wait for playback to finish
+        playback_finished.wait()
+        print("Playback finished.")
+
+except Exception as e:
+    print(f"An error occurred: {e}")
+    # Ensure thread exits if there's a main thread error
+    audio_queue.put(None)
+

--- a/tests/run_tts.py
+++ b/tests/run_tts.py
@@ -1,0 +1,24 @@
+from supertonic_mnn import SupertonicTTS
+
+def read_file_to_string(filename):
+    try:
+        with open(filename, 'r', encoding='utf-8') as file:
+            # Read the entire file content into a single string variable
+            file_contents = file.read()
+        return file_contents
+    except FileNotFoundError:
+        return f"Error: The file '{filename}' was not found."
+    except Exception as e:
+        return f"An unexpected error occurred: {e}"
+
+file_name = 'tts.txt'
+data_string = read_file_to_string(file_name)
+
+
+# Initialize
+tts = SupertonicTTS()
+
+# Synthesize
+# Models will be downloaded automatically if not present
+audio, sample_rate = tts.synthesize(data_string, voice="F1", output_file="hello.wav", steps=9)
+

--- a/tests/tts.txt
+++ b/tests/tts.txt
@@ -1,0 +1,199 @@
+CHAPTER 1. Loomings.
+
+Call me Ishmael. Some years ago—never mind how long precisely—having
+little or no money in my purse, and nothing particular to interest me
+on shore, I thought I would sail about a little and see the watery part
+of the world. It is a way I have of driving off the spleen and
+regulating the circulation. Whenever I find myself growing grim about
+the mouth; whenever it is a damp, drizzly November in my soul; whenever
+I find myself involuntarily pausing before coffin warehouses, and
+bringing up the rear of every funeral I meet; and especially whenever
+my hypos get such an upper hand of me, that it requires a strong moral
+principle to prevent me from deliberately stepping into the street, and
+methodically knocking people’s hats off—then, I account it high time to
+get to sea as soon as I can. This is my substitute for pistol and ball.
+With a philosophical flourish Cato throws himself upon his sword; I
+quietly take to the ship. There is nothing surprising in this. If they
+but knew it, almost all men in their degree, some time or other,
+cherish very nearly the same feelings towards the ocean with me.
+
+There now is your insular city of the Manhattoes, belted round by
+wharves as Indian isles by coral reefs—commerce surrounds it with her
+surf. Right and left, the streets take you waterward. Its extreme
+downtown is the battery, where that noble mole is washed by waves, and
+cooled by breezes, which a few hours previous were out of sight of
+land. Look at the crowds of water-gazers there.
+
+Circumambulate the city of a dreamy Sabbath afternoon. Go from Corlears
+Hook to Coenties Slip, and from thence, by Whitehall, northward. What
+do you see?—Posted like silent sentinels all around the town, stand
+thousands upon thousands of mortal men fixed in ocean reveries. Some
+leaning against the spiles; some seated upon the pier-heads; some
+looking over the bulwarks of ships from China; some high aloft in the
+rigging, as if striving to get a still better seaward peep. But these
+are all landsmen; of week days pent up in lath and plaster—tied to
+counters, nailed to benches, clinched to desks. How then is this? Are
+the green fields gone? What do they here?
+
+But look! here come more crowds, pacing straight for the water, and
+seemingly bound for a dive. Strange! Nothing will content them but the
+extremest limit of the land; loitering under the shady lee of yonder
+warehouses will not suffice. No. They must get just as nigh the water
+as they possibly can without falling in. And there they stand—miles of
+them—leagues. Inlanders all, they come from lanes and alleys, streets
+and avenues—north, east, south, and west. Yet here they all unite. Tell
+me, does the magnetic virtue of the needles of the compasses of all
+those ships attract them thither?
+
+Once more. Say you are in the country; in some high land of lakes. Take
+almost any path you please, and ten to one it carries you down in a
+dale, and leaves you there by a pool in the stream. There is magic in
+it. Let the most absent-minded of men be plunged in his deepest
+reveries—stand that man on his legs, set his feet a-going, and he will
+infallibly lead you to water, if water there be in all that region.
+Should you ever be athirst in the great American desert, try this
+experiment, if your caravan happen to be supplied with a metaphysical
+professor. Yes, as every one knows, meditation and water are wedded for
+ever.
+
+But here is an artist. He desires to paint you the dreamiest, shadiest,
+quietest, most enchanting bit of romantic landscape in all the valley
+of the Saco. What is the chief element he employs? There stand his
+trees, each with a hollow trunk, as if a hermit and a crucifix were
+within; and here sleeps his meadow, and there sleep his cattle; and up
+from yonder cottage goes a sleepy smoke. Deep into distant woodlands
+winds a mazy way, reaching to overlapping spurs of mountains bathed in
+their hill-side blue. But though the picture lies thus tranced, and
+though this pine-tree shakes down its sighs like leaves upon this
+shepherd’s head, yet all were vain, unless the shepherd’s eye were
+fixed upon the magic stream before him. Go visit the Prairies in June,
+when for scores on scores of miles you wade knee-deep among
+Tiger-lilies—what is the one charm wanting?—Water—there is not a drop
+of water there! Were Niagara but a cataract of sand, would you travel
+your thousand miles to see it? Why did the poor poet of Tennessee, upon
+suddenly receiving two handfuls of silver, deliberate whether to buy
+him a coat, which he sadly needed, or invest his money in a pedestrian
+trip to Rockaway Beach? Why is almost every robust healthy boy with a
+robust healthy soul in him, at some time or other crazy to go to sea?
+Why upon your first voyage as a passenger, did you yourself feel such a
+mystical vibration, when first told that you and your ship were now out
+of sight of land? Why did the old Persians hold the sea holy? Why did
+the Greeks give it a separate deity, and own brother of Jove? Surely
+all this is not without meaning. And still deeper the meaning of that
+story of Narcissus, who because he could not grasp the tormenting, mild
+image he saw in the fountain, plunged into it and was drowned. But that
+same image, we ourselves see in all rivers and oceans. It is the image
+of the ungraspable phantom of life; and this is the key to it all.
+
+Now, when I say that I am in the habit of going to sea whenever I begin
+to grow hazy about the eyes, and begin to be over conscious of my
+lungs, I do not mean to have it inferred that I ever go to sea as a
+passenger. For to go as a passenger you must needs have a purse, and a
+purse is but a rag unless you have something in it. Besides, passengers
+get sea-sick—grow quarrelsome—don’t sleep of nights—do not enjoy
+themselves much, as a general thing;—no, I never go as a passenger;
+nor, though I am something of a salt, do I ever go to sea as a
+Commodore, or a Captain, or a Cook. I abandon the glory and distinction
+of such offices to those who like them. For my part, I abominate all
+honorable respectable toils, trials, and tribulations of every kind
+whatsoever. It is quite as much as I can do to take care of myself,
+without taking care of ships, barques, brigs, schooners, and what not.
+And as for going as cook,—though I confess there is considerable glory
+in that, a cook being a sort of officer on ship-board—yet, somehow, I
+never fancied broiling fowls;—though once broiled, judiciously
+buttered, and judgmatically salted and peppered, there is no one who
+will speak more respectfully, not to say reverentially, of a broiled
+fowl than I will. It is out of the idolatrous dotings of the old
+Egyptians upon broiled ibis and roasted river horse, that you see the
+mummies of those creatures in their huge bake-houses the pyramids.
+
+No, when I go to sea, I go as a simple sailor, right before the mast,
+plumb down into the forecastle, aloft there to the royal mast-head.
+True, they rather order me about some, and make me jump from spar to
+spar, like a grasshopper in a May meadow. And at first, this sort of
+thing is unpleasant enough. It touches one’s sense of honor,
+particularly if you come of an old established family in the land, the
+Van Rensselaers, or Randolphs, or Hardicanutes. And more than all, if
+just previous to putting your hand into the tar-pot, you have been
+lording it as a country schoolmaster, making the tallest boys stand in
+awe of you. The transition is a keen one, I assure you, from a
+schoolmaster to a sailor, and requires a strong decoction of Seneca and
+the Stoics to enable you to grin and bear it. But even this wears off
+in time.
+
+What of it, if some old hunks of a sea-captain orders me to get a broom
+and sweep down the decks? What does that indignity amount to, weighed,
+I mean, in the scales of the New Testament? Do you think the archangel
+Gabriel thinks anything the less of me, because I promptly and
+respectfully obey that old hunks in that particular instance? Who ain’t
+a slave? Tell me that. Well, then, however the old sea-captains may
+order me about—however they may thump and punch me about, I have the
+satisfaction of knowing that it is all right; that everybody else is
+one way or other served in much the same way—either in a physical or
+metaphysical point of view, that is; and so the universal thump is
+passed round, and all hands should rub each other’s shoulder-blades,
+and be content.
+
+Again, I always go to sea as a sailor, because they make a point of
+paying me for my trouble, whereas they never pay passengers a single
+penny that I ever heard of. On the contrary, passengers themselves must
+pay. And there is all the difference in the world between paying and
+being paid. The act of paying is perhaps the most uncomfortable
+infliction that the two orchard thieves entailed upon us. But _being
+paid_,—what will compare with it? The urbane activity with which a man
+receives money is really marvellous, considering that we so earnestly
+believe money to be the root of all earthly ills, and that on no
+account can a monied man enter heaven. Ah! how cheerfully we consign
+ourselves to perdition!
+
+Finally, I always go to sea as a sailor, because of the wholesome
+exercise and pure air of the fore-castle deck. For as in this world,
+head winds are far more prevalent than winds from astern (that is, if
+you never violate the Pythagorean maxim), so for the most part the
+Commodore on the quarter-deck gets his atmosphere at second hand from
+the sailors on the forecastle. He thinks he breathes it first; but not
+so. In much the same way do the commonalty lead their leaders in many
+other things, at the same time that the leaders little suspect it. But
+wherefore it was that after having repeatedly smelt the sea as a
+merchant sailor, I should now take it into my head to go on a whaling
+voyage; this the invisible police officer of the Fates, who has the
+constant surveillance of me, and secretly dogs me, and influences me in
+some unaccountable way—he can better answer than any one else. And,
+doubtless, my going on this whaling voyage, formed part of the grand
+programme of Providence that was drawn up a long time ago. It came in
+as a sort of brief interlude and solo between more extensive
+performances. I take it that this part of the bill must have run
+something like this:
+
+“_Grand Contested Election for the Presidency of the United States._
+“WHALING VOYAGE BY ONE ISHMAEL. “BLOODY BATTLE IN AFFGHANISTAN.”
+
+Though I cannot tell why it was exactly that those stage managers, the
+Fates, put me down for this shabby part of a whaling voyage, when
+others were set down for magnificent parts in high tragedies, and short
+and easy parts in genteel comedies, and jolly parts in farces—though I
+cannot tell why this was exactly; yet, now that I recall all the
+circumstances, I think I can see a little into the springs and motives
+which being cunningly presented to me under various disguises, induced
+me to set about performing the part I did, besides cajoling me into the
+delusion that it was a choice resulting from my own unbiased freewill
+and discriminating judgment.
+
+Chief among these motives was the overwhelming idea of the great whale
+himself. Such a portentous and mysterious monster roused all my
+curiosity. Then the wild and distant seas where he rolled his island
+bulk; the undeliverable, nameless perils of the whale; these, with all
+the attending marvels of a thousand Patagonian sights and sounds,
+helped to sway me to my wish. With other men, perhaps, such things
+would not have been inducements; but as for me, I am tormented with an
+everlasting itch for things remote. I love to sail forbidden seas, and
+land on barbarous coasts. Not ignoring what is good, I am quick to
+perceive a horror, and could still be social with it—would they let
+me—since it is but well to be on friendly terms with all the inmates of
+the place one lodges in.
+
+By reason of these things, then, the whaling voyage was welcome; the
+great flood-gates of the wonder-world swung open, and in the wild
+conceits that swayed me to my purpose, two and two there floated into
+my inmost soul, endless processions of the whale, and, mid most of them
+all, one grand hooded phantom, like a snow hill in the air.

--- a/tests/verify_stream.py
+++ b/tests/verify_stream.py
@@ -1,0 +1,76 @@
+
+import time
+import numpy as np
+from supertonic_mnn import SupertonicTTS
+
+def read_file_to_string(filename):
+    """
+    Reads the entire content of a specified text file into a single string.
+    
+    Args:
+        filename (str): The path to the text file.
+
+    Returns:
+        str: The content of the file, or an error message if the file is not found.
+    """
+    try:
+        # 'with open(...) as file:' ensures the file is automatically closed
+        # 'r' mode opens the file for reading (default)
+        with open(filename, 'r', encoding='utf-8') as file:
+            # Read the entire file content into a single string variable
+            file_contents = file.read()
+        return file_contents
+    except FileNotFoundError:
+        return f"Error: The file '{filename}' was not found."
+    except Exception as e:
+        return f"An unexpected error occurred: {e}"
+
+def test_streaming():
+    print("Initializing SupertonicTTS...")
+    tts = SupertonicTTS()
+    
+    # A text long enough to be chunked (punctuation usually triggers chunking)
+    file_name = "tts.txt"
+    text = read_file_to_string(file_name)
+    
+    print("\n--- Starting Stream Synthesis ---")
+    print(f"Text: {text}")
+    
+    start_time = time.time()
+    chunk_count = 0
+    total_audio_len = 0
+    
+    try:
+        # Use the NEW synthesize_stream method
+        stream = tts.synthesize_stream(text, voice="F2", steps=9) # Low steps for speed
+        
+        for audio_chunk, sr in stream:
+            chunk_count += 1
+            chunk_duration = audio_chunk.shape[0] / sr
+            total_audio_len += chunk_duration
+            
+            elapsed = time.time() - start_time
+            print(f"Received Chunk #{chunk_count}: Duration={chunk_duration:.2f}s, Time from start={elapsed:.2f}s")
+            
+            # Simple check to ensure we got valid data
+            if not isinstance(audio_chunk, np.ndarray):
+                print("ERROR: Chunk is not a numpy array!")
+            if sr <= 0:
+                print("ERROR: Invalid sample rate!")
+
+        print("\n--- Stream Finished ---")
+        print(f"Total Chunks: {chunk_count}")
+        print(f"Total Audio Duration: {total_audio_len:.2f}s")
+        
+        if chunk_count > 1:
+            print("SUCCESS: Multiple chunks received, streaming is working effectively.")
+        else:
+            print("WARNING: Only 1 chunk received. While valid, it doesn't demonstrate streaming benefits (text might be too short).")
+
+    except Exception as e:
+        print(f"\nFATAL ERROR during streaming: {e}")
+        import traceback
+        traceback.print_exc()
+
+if __name__ == "__main__":
+    test_streaming()


### PR DESCRIPTION
## Description
This PR implements streaming, asynchronous audio synthesis for the Supertonic MNN engine. This allows the consumer to begin processing or playing back audio chunks (sentences/phrases) as soon as they are generated, rather than waiting for the entire text to be synthesized.

## Changes

> Basically you can call `tts.synthesize_stream` method now.

### Core Engine (`supertonic_mnn/engine.py`)
- Added `stream()` method to `TextToSpeech` class.
- This method is a generator that yields `(audio_chunk, duration, elapsed_time)` tuples iteratively.
- Implements the same logic as `__call__` but uses `yield` instead of accumulating a large numpy array.

### Wrapper (`supertonic_mnn/wrapper.py`)
- Added `synthesize_stream()` method to `SupertonicTTS` class.
- **Explicit Streaming:** This method explicitly returns a Python generator object instead of a complete audio array. The expensive synthesis computation is deferred and runs incrementally only when the caller iterates (loops) over this generator.
- Exposes the engine's generator to the high-level API.
- Yields `(audio_chunk, sample_rate)`.

## Example
Look at `play_tts.py` for example usage. The `tts.txt` is Mobby Dick chapter 1.

## Verification
I have created some demos, they can be found at `test` directory. They are `verify_stream.py`, `play_tts.py`.
